### PR TITLE
Fixed a bug where an empty CVE dataset could be returned

### DIFF
--- a/nudge-auto-updater.py
+++ b/nudge-auto-updater.py
@@ -305,7 +305,9 @@ def get_CVE_scores(s:str, b:bool, api_key):
 	except Exception as e:
 		logging.error(f"Unable to load CVE data for {s}.")
 		sys.exit(1)
-	if "cvssMetricV31" in result["data"][0]["metrics"]:
+	if result["_meta"]["total_documents"] < 1:
+		return None
+	elif "cvssMetricV31" in result["data"][0]["metrics"]:
 		return read_CVE_scores(result["data"][0]["metrics"]["cvssMetricV31"][0], b)
 	else:
 		return None


### PR DESCRIPTION
Fixes an issue where, if there is no assessment of a CVE at Vulncheck, an IndexError could occur.

This was caused by a suspected upstream API change.

Thanks to Henning Kessler for reporting!