### PR TITLE
Fix broken URLs (#11)

### DIFF
--- a/nudge-auto-updater.py
+++ b/nudge-auto-updater.py
@@ -235,7 +235,10 @@ def update_nudge_file_dict(d:dict, target, version, url, release_date, days):
 def adjust_url(url, change):
 	i = url.rfind("/") + 1
 	url = url[:i]
-	url += change
+	if change != "This update has no published CVE entries.":
+		url += change
+	else:
+		url += "100100" # https://support.apple.com/en-us/100100
 	return url
 
 def adjust_date_str(datestr, release_date, days):


### PR DESCRIPTION
This commit includes a fix for a bug where no CVEs being patched in a release led to malformed/broken URLs in the Nudge configuration.

Because (to retain localisation within the URLs) we only ever _edit_ existing URLs from the config rather than replace them, the default URL should match the pattern `https://support.apple.com/<locale>/<KB number>`. For this reason, if a macOS update does not contain fixes for any CVEs (specifically, if the text "This update has no published CVE entries." appears in the SOFA feed), the URL will be set to `https://support.apple.com/<locale>/100100` ([Apple's Security Releases homepage](https://support.apple.com/en-us/100100)).