### PR TITLE
Fix accented characters being written to the file as their unicode sequences.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 run.sh
 summary.md
+nudge-config.json

--- a/nudge-auto-updater.py
+++ b/nudge-auto-updater.py
@@ -215,7 +215,7 @@ def read_nudge_requirements(d:dict):
 def write_nudge_config(nudge_file_name:str, d:dict):
 	try:
 		with open(nudge_file_name, 'w') as f:
-			json.dump(d, f, indent=4)
+			json.dump(d, f, indent=4, ensure_ascii=False).encode('utf8')
 	except Exception as e:
 		logging.error(f"Unable to write to {nudge_file_name}")
 		sys.exit(1)

--- a/nudge-auto-updater.py
+++ b/nudge-auto-updater.py
@@ -215,9 +215,10 @@ def read_nudge_requirements(d:dict):
 def write_nudge_config(nudge_file_name:str, d:dict):
 	try:
 		with open(nudge_file_name, 'w') as f:
-			json.dump(d, f, indent=4, ensure_ascii=False).encode('utf8')
+			json.dump(d, f, indent=4, ensure_ascii=False)
 	except Exception as e:
 		logging.error(f"Unable to write to {nudge_file_name}")
+		logging.error(e)
 		sys.exit(1)
 
 def update_nudge_file_dict(d:dict, target, version, url, release_date, days):


### PR DESCRIPTION
Fixes an issue where accented characters would be overwritten with their unicode escape sequences (#18). 
Thanks to @hbokh for reporting!